### PR TITLE
VRP & Gear animation.

### DIFF
--- a/Mirage-2000/Mirage2000-vsp.xml
+++ b/Mirage-2000/Mirage2000-vsp.xml
@@ -40,10 +40,10 @@
     <y>0</y>
     <z>-3.94</z>
   </location>
-  <location unit="IN" name="VRP">
-    <x>290</x>
+  <location unit="M" name="VRP">
+    <x>6.812</x>
     <y>0</y>
-    <z>44</z>
+    <z>1.118</z>
   </location>
   <location unit="M" name="AERORP">
     <x>8.56</x>

--- a/Mirage-2000/Mirage2000-vsp.xml
+++ b/Mirage-2000/Mirage2000-vsp.xml
@@ -69,9 +69,9 @@
   <contact type="BOGEY" name="NOSE_LG">
     <!--0: NOSE_LG-->
     <location unit="M">
-      <x>4.01</x>
+      <x>4.82</x>
       <y>0</y>
-      <z>-1.478</z>
+      <z>-1.488</z>
     </location>
     <static_friction>1.0</static_friction>
     <dynamic_friction>0.5</dynamic_friction>

--- a/Mirage-2000/Mirage2000-vsp.xml
+++ b/Mirage-2000/Mirage2000-vsp.xml
@@ -76,8 +76,8 @@
     <static_friction>1.0</static_friction>
     <dynamic_friction>0.5</dynamic_friction>
     <rolling_friction>0.02</rolling_friction>
-    <spring_coeff unit="LBS/FT">15000</spring_coeff>
-    <damping_coeff unit="LBS/FT/SEC">1600</damping_coeff>
+    <spring_coeff unit="LBS/FT">20000</spring_coeff>
+    <damping_coeff unit="LBS/FT/SEC">2000</damping_coeff>
     <max_steer unit="DEG">45</max_steer>
     <brake_group>NOSE</brake_group>
     <retractable>1</retractable>
@@ -92,8 +92,8 @@
     <static_friction>1.0</static_friction>
     <dynamic_friction>0.5</dynamic_friction>
     <rolling_friction>0.02</rolling_friction>
-    <spring_coeff unit="LBS/FT">30000</spring_coeff>
-    <damping_coeff unit="LBS/FT/SEC">2200</damping_coeff>
+    <spring_coeff unit="LBS/FT">40000</spring_coeff>
+    <damping_coeff unit="LBS/FT/SEC">3000</damping_coeff>
     <max_steer unit="DEG">0</max_steer>
     <brake_group>LEFT</brake_group>
     <retractable>1</retractable>
@@ -108,8 +108,8 @@
     <static_friction>1.0</static_friction>
     <dynamic_friction>0.5</dynamic_friction>
     <rolling_friction>0.02</rolling_friction>
-    <spring_coeff unit="LBS/FT">30000</spring_coeff>
-    <damping_coeff unit="LBS/FT/SEC">2200</damping_coeff>
+    <spring_coeff unit="LBS/FT">40000</spring_coeff>
+    <damping_coeff unit="LBS/FT/SEC">3000</damping_coeff>
     <max_steer unit="DEG">0</max_steer>
     <brake_group>RIGHT</brake_group>
     <retractable>1</retractable>

--- a/Mirage-2000/Models/main.xml
+++ b/Mirage-2000/Models/main.xml
@@ -1224,7 +1224,7 @@
     <property>gear/gear[0]/compression-norm</property>
     <interpolation>
       <entry><ind> 0.00000000 </ind><dep> 0.00 </dep></entry>
-      <entry><ind> 0.74000000 </ind><dep> 0.21 </dep></entry>
+      <entry><ind> 0.56000000 </ind><dep> 0.21 </dep></entry>
     </interpolation>
     <axis>
       <x> 0 </x>
@@ -1239,7 +1239,7 @@
     <property>gear/gear[0]/compression-norm</property>
     <interpolation>
       <entry><ind> 0.00000000 </ind><dep>  0 </dep></entry>
-      <entry><ind> 0.74000000 </ind><dep> 47 </dep></entry>
+      <entry><ind> 0.56000000 </ind><dep> 47 </dep></entry>
     </interpolation>
     <center>
       <x-m> -2.998 </x-m>
@@ -1259,7 +1259,7 @@
     <property>gear/gear[0]/compression-norm</property>
     <interpolation>
       <entry><ind> 0.00000000 </ind><dep>   0 </dep></entry>
-      <entry><ind> 0.74000000 </ind><dep> -47 </dep></entry>
+      <entry><ind> 0.56000000 </ind><dep> -47 </dep></entry>
     </interpolation>
     <center>
       <x-m> -2.981 </x-m>
@@ -1287,7 +1287,7 @@
     <property>gear/gear[1]/compression-norm</property>
     <interpolation>
       <entry><ind> 0.000000 </ind><dep> -0.07 </dep></entry>
-      <entry><ind> 0.790000 </ind><dep>  0.17 </dep></entry>
+      <entry><ind> 0.790000 </ind><dep>  0.15 </dep></entry>
     </interpolation>
     <axis>
       <x1-m>  1.949 </x1-m>
@@ -1349,7 +1349,7 @@
     <property>gear/gear[2]/compression-norm</property>
     <interpolation>
       <entry><ind> 0.000000 </ind><dep> -0.07 </dep></entry>
-      <entry><ind> 0.790000 </ind><dep>  0.17 </dep></entry>
+      <entry><ind> 0.790000 </ind><dep>  0.15 </dep></entry>
     </interpolation>
     <axis>
       <x1-m>  1.949 </x1-m>


### PR DESCRIPTION
Resolves #80 
Setting the proper value for the VRP(x) : 6.812
Tweaking the gear animation to follow the ground.
Tweaking the gear springs & dampers to avoid full damper stroke on takeoff rotation and to have a bit more VS tolerance on landing.