### PR TITLE
use view-number-raw instead of view-number, fix (?) for MissileView

### DIFF
--- a/Mirage-2000/Models/Interior/interior.xml
+++ b/Mirage-2000/Models/Interior/interior.xml
@@ -91,13 +91,13 @@
             <value>1</value>
           </equals>
           <equals>
-            <property>/sim/current-view/view-number</property>
+            <property>/sim/current-view/view-number-raw</property>
             <value>0</value>
           </equals>
         </and>
         <not>
           <equals>
-            <property>/sim/current-view/view-number</property>
+            <property>/sim/current-view/view-number-raw</property>
             <value>0</value>
           </equals>
         </not>

--- a/Mirage-2000/Models/Interior/interiorB.xml
+++ b/Mirage-2000/Models/Interior/interiorB.xml
@@ -112,13 +112,13 @@
             <value>1</value>
           </equals>
           <equals>
-            <property>/sim/current-view/view-number</property>
+            <property>/sim/current-view/view-number-raw</property>
             <value>0</value>
           </equals>
         </and>
         <not>
           <equals>
-            <property>/sim/current-view/view-number</property>
+            <property>/sim/current-view/view-number-raw</property>
             <value>0</value>
           </equals>
         </not>
@@ -143,14 +143,14 @@
             <value>1</value>
           </equals>
           <equals>
-            <property>/sim/current-view/view-number</property>
-            <value>11</value>
+            <property>/sim/current-view/view-number-raw</property>
+            <value>103</value>
           </equals>
         </and>
         <not>
           <equals>
-            <property>/sim/current-view/view-number</property>
-            <value>11</value>
+            <property>/sim/current-view/view-number-raw</property>
+            <value>103</value>
           </equals>
         </not>
       </or>

--- a/Mirage-2000/Nasal/MissileView.nas
+++ b/Mirage-2000/Nasal/MissileView.nas
@@ -70,24 +70,25 @@ var missile_view_handler = {
     if (data.root == '/') {
       var zoffset = getprop("/sim/chase-distance-m");
     } else {
-      var zoffset = 30;
+      var zoffset = -30;
       var load_heading = int(getprop(data.root ~ "/orientation/true-heading-deg"));
       var offset_heading = load_heading>180? 540-load_heading :(180 - load_heading);
       var offset_pitch = int(getprop(data.root ~ "/orientation/pitch-deg")) - 5;
 #       print("Missile heading : "~ load_heading ~" view heading offstet should be : "~ (360 - load_heading - 180) ~ " MyTest:" ~ myTest);
       
       
-      setprop("/sim/current-view/heading-offset-deg", offset_heading);
-      setprop("/sim/current-view/pitch-offset-deg", offset_pitch);
+      # setprop("/sim/current-view/heading-offset-deg", offset_heading);
+      # setprop("/sim/current-view/pitch-offset-deg", offset_pitch);
       
-      setprop("/sim/current-view/config/heading-offset-deg", offset_heading);
-      setprop("/sim/current-view/config/pitch-offset-deg", offset_pitch);
+      setprop("/sim/view[101]/config/heading-offset-deg", offset_heading);
+      setprop("/sim/view[101]/config/pitch-offset-deg", offset_pitch);
     }
 
     me.current = data.callsign;
     me.legendN.setValue(ident);  
 
-    setprop("/sim/current-view/z-offset-m", zoffset);
+    print(zoffset);
+    setprop("/sim/view[101]/config/z-offset-m", zoffset);
 
     
     #print("me.current:"~me.current);
@@ -130,25 +131,25 @@ var view_firing_missile = func(myMissile)
     var myMissileName = string.replace(myMissile.ai.getPath(), "/ai/models/", "");
 
     # We memorize the initial view number
-    var actualView = getprop("/sim/current-view/view-number");
-#     setprop("/sim/current-view/view-number",9);
-#     setprop("/sim/current-view/view-number",actualView);
+#   var actualView = getprop("/sim/current-view/view-number-raw");
+#     setprop("/sim/current-view/view-number-raw", 101);
+#     setprop("/sim/current-view/view-number-raw",actualView);
 
     # We recreate the data vector to feed the missile_view_handler  
     var data = { node: myMissile.ai, callsign: myMissileName, root: myMissile.ai.getPath()};
 
     # We activate the AI view (on this aircraft it is the number 9)
-    setprop("/sim/current-view/view-number",9);
+    setprop("/sim/current-view/view-number-raw", 101);
     # setprop("/sim/current-view/heading-offset-deg", 160);
 
     # We feed the handler
     view.missile_view_handler.setup(data);
 }
 var init_missile_view = func(){
-  setprop("/sim/current-view/view-number",9);
+  setprop("/sim/current-view/view-number-raw", 101);
   setprop("/sim/current-view/heading-offset-deg", 0);
   var timer = maketimer(3,func(){
-    setprop("/sim/current-view/view-number", 0);
+    setprop("/sim/current-view/view-number-raw", 0);
   });
   timer.singleShot = 1; # timer will only be run once
   timer.start();

--- a/Mirage-2000/Nasal/m2000-5.nas
+++ b/Mirage-2000/Nasal/m2000-5.nas
@@ -536,7 +536,7 @@ var init_EjectionKey = func(){
 
 var flightmode = func (){
   #print("Called");
-  if(getprop("/sim/current-view/view-number") == 0) {
+  if(getprop("/sim/current-view/view-number-raw") == 0) {
     if(getprop("/instrumentation/flightmode/app")){
       setprop("/sim/current-view/x-offset-m",0);
       setprop("/sim/current-view/y-offset-m",0.1019);
@@ -667,7 +667,7 @@ var quickstart = func() {
       call(func{fgcommand('dialog-close', props.Node.new({"dialog-name": "config"}))},nil,var err2 = []);
     
       #Placing the view on take off view
-      if(getprop("/sim/current-view/view-number") == 0) {
+      if(getprop("/sim/current-view/view-number-raw") == 0) {
         setprop("/sim/current-view/x-offset-m",0);
         setprop("/sim/current-view/y-offset-m",0.1019);
         setprop("/sim/current-view/z-offset-m",-2.9);
@@ -694,7 +694,7 @@ var quickstart = func() {
 
       #Zooming on starting panel
       settimer(func {
-        if(getprop("/sim/current-view/view-number") == 0) {
+        if(getprop("/sim/current-view/view-number-raw") == 0) {
           setprop("/sim/current-view/pitch-offset-deg",-62);
           setprop("/sim/current-view/heading-offset-deg",312);
           setprop("/sim/current-view/field-of-view",21.6);
@@ -741,7 +741,7 @@ var quickstart = func() {
       
       #zooming on fuel, electrics and alerts
       settimer(func {
-        if(getprop("/sim/current-view/view-number") == 0) {
+        if(getprop("/sim/current-view/view-number-raw") == 0) {
           setprop("/sim/current-view/pitch-offset-deg",-38);
           setprop("/sim/current-view/heading-offset-deg",338);
           setprop("/sim/current-view/field-of-view",36);
@@ -750,7 +750,7 @@ var quickstart = func() {
 
      #puting back the view on take off view
       settimer(func {
-        if(getprop("/sim/current-view/view-number") == 0) {
+        if(getprop("/sim/current-view/view-number-raw") == 0) {
           setprop("/sim/current-view/pitch-offset-deg",-14);
           setprop("/sim/current-view/heading-offset-deg",0);
           setprop("/sim/current-view/field-of-view",83);

--- a/Mirage-2000/Systems/m2000-5-keyboard.xml
+++ b/Mirage-2000/Systems/m2000-5-keyboard.xml
@@ -205,20 +205,11 @@
     <key n="119">
       <name>w</name>
       <desc>Cycle Stick Weapon Mode Selector</desc>
-<!--      <binding>
-        <command>property-adjust</command>
-        <property>controls/armament/stick-selector</property>
-        <step>1</step>
-        <min>0</min>
-        <max>4</max>
-        <repeat>false</repeat>
-        <wrap>true</wrap>
-      </binding>-->
       <binding>
         <command>nasal</command>
         <script>
             pylons.fcs.cycleLoadedWeapon();
-            setprop("/controls/armament/name",pylons.fcs.selectedType);
+            setprop("/controls/armament/name", pylons.fcs.getSelectedType());
         </script>
       </binding>
     </key>

--- a/Mirage-2000/Tutorials/autopilot_beginner_tutorial.xml
+++ b/Mirage-2000/Tutorials/autopilot_beginner_tutorial.xml
@@ -64,7 +64,7 @@ Sorry, the only instructor we found is french but he is nice anyway ;)
         <value>0.0</value>
     </set>-->
     <set>
-      <property>/sim/current-view/view-number</property>
+      <property>/sim/current-view/view-number-raw</property>
       <value>0</value>
     </set>
   </init>

--- a/Mirage-2000/Tutorials/engine_starting_tutorial.xml
+++ b/Mirage-2000/Tutorials/engine_starting_tutorial.xml
@@ -7,7 +7,7 @@
 
   <init>
     <set>
-      <property>/sim/current-view/view-number</property>
+      <property>/sim/current-view/view-number-raw</property>
       <value>0</value>
     </set>
   </init>


### PR DESCRIPTION
Change all references to `/sim/current-view/view-number` to `/sim/current-view/view-number-raw`
`/sim/current-view/view-number` is dependent on the number of views, as recently still-view was added to 2020.4 (and will be merged to 2020.3.7) it broke missile-view. For this reason the -raw property should be used
Fixed a nasal issue with the weapon cycle binding
Attempted to fix missile view. Not perfect, but not totally broken anymore.